### PR TITLE
Fix data sync failing on reload

### DIFF
--- a/forge/src/main/java/com/github/teamfossilsarcheology/fossil/forge/event/ForgeModEvents.java
+++ b/forge/src/main/java/com/github/teamfossilsarcheology/fossil/forge/event/ForgeModEvents.java
@@ -161,6 +161,14 @@ public class ForgeModEvents {
 
     @SubscribeEvent
     public static void onDatapackSyncEvent(OnDatapackSyncEvent event) {
-        FossilMod.syncData(event.getPlayer());
+        //On join
+        ServerPlayer p = event.getPlayer();
+        if(p != null) FossilMod.syncData(p);
+
+        //On reload
+        for(ServerPlayer sp : event.getPlayers())
+        {
+            FossilMod.syncData(sp);
+        }
     }
 }


### PR DESCRIPTION
Related to issue #66 
When reloading, ForgeModeEvents#onDatapackSyncEvent fails as the targeted player is null. This causes the entire reload to fail, giving the "Reload failed; keeping old data" message.
This is because OnDatapackSyncEvent#getPlayer returns null when reloading. As such, an additional case can be added to send the data to all players on reload.
Please let me know if I've misinterpreted anything.