### PR TITLE
Improve flying mob movement and behavior

### DIFF
--- a/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/ai/FlyingWanderGoal.java
+++ b/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/ai/FlyingWanderGoal.java
@@ -3,7 +3,6 @@ package com.github.teamfossilsarcheology.fossil.entity.ai;
 import com.github.teamfossilsarcheology.fossil.entity.prehistoric.base.OrderType;
 import com.github.teamfossilsarcheology.fossil.entity.prehistoric.base.PrehistoricFlying;
 import net.minecraft.core.BlockPos;
-import net.minecraft.util.Mth;
 import net.minecraft.world.entity.ai.goal.Goal;
 import net.minecraft.world.phys.Vec3;
 
@@ -13,7 +12,6 @@ public class FlyingWanderGoal extends Goal {
     protected final PrehistoricFlying dino;
     private Vec3 targetPos;
     private boolean shouldLand;
-    private boolean isRotating;
 
     public FlyingWanderGoal(PrehistoricFlying dino) {
         this.dino = dino;
@@ -22,12 +20,11 @@ public class FlyingWanderGoal extends Goal {
 
     @Override
     public boolean canUse() {
-        boolean debugLand = false;//TODO: Remove debug
         if (dino.isVehicle() || dino.getCurrentOrder() != OrderType.WANDER || !dino.isAdult()) {
             return false;
         }
         if (dino.isFlying()) {
-            if (debugLand || dino.getRandom().nextInt(50) == 0) {
+            if (dino.getRandom().nextInt(900) == 0) {
                 BlockPos landPosition = dino.findLandPosition(false);
                 if (landPosition != null) {
                     shouldLand = true;
@@ -36,11 +33,16 @@ public class FlyingWanderGoal extends Goal {
                 }
                 return false;
             }
-            targetPos = findAirTarget();
-            return targetPos != null;
+            // Only pick a new air target occasionally — without this gate the
+            // goal fires every tick and the mob changes direction constantly.
+            if (dino.getRandom().nextInt(2) == 0) {
+                targetPos = findAirTarget();
+                return targetPos != null;
+            }
+            return false;
         } else if (dino.onGround()) {
             boolean debug = false;
-            if (debug||dino.getRandom().nextInt(250) == 0) {
+            if (debug || dino.getRandom().nextInt(600) == 0) {
                 targetPos = findAirTarget();
                 return targetPos != null;
             }
@@ -53,7 +55,7 @@ public class FlyingWanderGoal extends Goal {
         if (dino.isFlying()) {
             return dino.getMoveControl().hasWanted();
         }
-        return isRotating || dino.isTakingOff();
+        return dino.isTakingOff();
     }
 
     @Override
@@ -70,7 +72,6 @@ public class FlyingWanderGoal extends Goal {
     @Override
     public void stop() {
         shouldLand = false;
-        isRotating = false;
         targetPos = null;
     }
 
@@ -83,21 +84,11 @@ public class FlyingWanderGoal extends Goal {
 
     private void performTakeOff() {
         if (!dino.isTakingOff()) {
-            Vec3 distance = targetPos.subtract(dino.position());
-            float rot = (float) (Mth.atan2(distance.z, distance.x) * Mth.RAD_TO_DEG - 90);
-            float diff = Mth.degreesDifference(rot, dino.yBodyRot);
-            if (diff > 45 && false) {//TODO: Can break if directly aboe target I think
-                isRotating = true;
-                dino.getLookControl().setLookAt(targetPos);
-            } else {
-                isRotating = false;
                 dino.moveTo(targetPos, false, true);
-            }
         }
     }
 
     private Vec3 findAirTarget() {
-        //TODO: Different flight patterns. Do circles around point, Fly straight for a bit, random etc
         return dino.generateAirTarget();
     }
 }

--- a/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/ai/control/CustomFlightMoveControl.java
+++ b/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/ai/control/CustomFlightMoveControl.java
@@ -53,89 +53,103 @@ public class CustomFlightMoveControl extends SmoothTurningMoveControl {
         this.operation = operation;
     }
 
+    public boolean isShouldLandAtTarget() {
+        return shouldLandAtTarget;
+    }
+
     @Override
     public void tick() {
         if (!mob.isFlying()) {
+            mob.setXRot(0);
             mob.setNoGravity(false);
             super.tick();
-        } else if (operation == Operation.MOVE_TO) {
+            return;
+        }
+
+        if (mob.isVehicle()) {
             mob.setNoGravity(true);
-            Vec3 offset = flyingWanted.subtract(mob.position());
-            double dist = offset.length();
-            if (dist > Math.min(1.5, mob.getBbWidth())) {
-                float initialYRot = mob.getYRot();
-                float initialXRot = mob.getXRot();
-                float initialYaw = Util.yRotToYaw(initialYRot);
+            return;
+        }
 
-                float targetYaw = (float) Mth.atan2(offset.z, offset.x) * Mth.RAD_TO_DEG;//atan2 always returns between -180 and 180 so no wrapdegrees needed
-                float targetPitch = (float) Mth.atan2(-offset.y, offset.horizontalDistance()) * Mth.RAD_TO_DEG;
+        if (operation != Operation.MOVE_TO) {
+            mob.setNoGravity(!shouldLandAtTarget);
+            return;
+        }
 
-                float newYaw = Mth.approachDegrees(initialYaw, targetYaw, 4);
-                float newPitch = Mth.approachDegrees(initialXRot, targetPitch, 4);
+        mob.setNoGravity(!shouldLandAtTarget);
+        Vec3 offset = flyingWanted.subtract(mob.position());
+        double dist = offset.length();
 
-                mob.setYRot(Util.yawToYRot(newYaw));
-                mob.yBodyRot = mob.getYRot();
-                mob.setXRot(newPitch);
-                if (Mth.degreesDifferenceAbs(initialYRot, mob.getYRot()) < 3) {
-                    //Slows down before reaching the target to prevent overshooting
-                    float limit = 1.2f;
-                    if (dist > 15) {
-                        limit = 2.2f;
-                    } else if (dist > 5) {
-                        limit = 1.8f;
-                    }
-                    limit = shouldLandAtTarget ? limit * 0.8f : limit;
-                    speedModifier = Mth.approach((float) speedModifier, limit, (float) (0.05 * (1.8 / speedModifier)));
-                } else {
-                    speedModifier = Mth.approach((float) speedModifier, 0.2f, 0.025f);
-                }
+        if (dist > Math.min(1.5, mob.getBbWidth())) {
 
-                double targetXMove = speedModifier * Mth.cos(newYaw * Mth.DEG_TO_RAD) * Math.abs(offset.x / dist);
-                double targetYMove = speedModifier * Mth.sin(-targetPitch * Mth.DEG_TO_RAD) * Math.abs(offset.y / dist);
-                double targetZMove = speedModifier * Mth.sin(newYaw * Mth.DEG_TO_RAD) * Math.abs(offset.z / dist);
-                Vec3 move = mob.getDeltaMovement();
-                double newX = Mth.approach((float) move.x, (float) targetXMove, 0.01f);
-                double newY = Mth.approach((float) move.y, (float) targetYMove, 0.01f);
-                double newZ = Mth.approach((float) move.z, (float) targetZMove, 0.01f);
-                mob.setDeltaMovement(newX, newY, newZ);
+            float currentYaw = Util.yRotToYaw(mob.getYRot());
+            float targetYaw  = (float) Mth.atan2(offset.z, offset.x) * Mth.RAD_TO_DEG;
+
+            // Fly straight toward the target.
+            float newYaw = targetYaw;
+
+            mob.setYRot(Util.yawToYRot(newYaw));
+            mob.yBodyRot = mob.getYRot();
+
+            float targetPitch = (float) Mth.atan2(-offset.y, offset.horizontalDistance()) * Mth.RAD_TO_DEG;
+            float newPitch    = Mth.approachDegrees(mob.getXRot(), targetPitch, 4);
+            mob.setXRot(newPitch);
+
+            if (Mth.degreesDifferenceAbs(Util.yRotToYaw(mob.getYRot()), newYaw) < 3) {
+                float limit = 1.2f;
+                if (dist > 15)     limit = 2.2f;
+                else if (dist > 5) limit = 1.8f;
+                limit = shouldLandAtTarget ? limit * 0.8f : limit;
+                speedModifier = Mth.approach((float) speedModifier, limit, (float) (0.05 * (1.8 / speedModifier)));
             } else {
-                if (mob.isUsingStuckNavigation()) {
-                    mob.switchNavigator(false);
-                }
-                if (shouldLandAtTarget) {
-                    if (!mob.level().isEmptyBlock(mob.blockPosition().below())) {
-                        mob.onReachAirTarget(BlockPos.containing(flyingWanted));//TODO: Maybe onReachGroundTarget?
-                        mob.setFlying(false);
-                        operation = Operation.WAIT;
-                    }
-                } else {
+                speedModifier = Mth.approach((float) speedModifier, 0.2f, 0.025f);
+            }
+
+            double targetXMove = speedModifier * Mth.cos(newYaw * Mth.DEG_TO_RAD) * Math.abs(offset.x / dist);
+            double targetYMove = speedModifier * Mth.sin(-targetPitch * Mth.DEG_TO_RAD) * Math.abs(offset.y / dist);
+            double targetZMove = speedModifier * Mth.sin(newYaw * Mth.DEG_TO_RAD) * Math.abs(offset.z / dist);
+            Vec3 move = mob.getDeltaMovement();
+            mob.setDeltaMovement(
+                    Mth.approach((float) move.x, (float) targetXMove, 0.01f),
+                    Mth.approach((float) move.y, (float) targetYMove, 0.01f),
+                    Mth.approach((float) move.z, (float) targetZMove, 0.01f));
+
+        } else {
+            if (mob.isUsingStuckNavigation()) {
+                mob.switchNavigator(false);
+            }
+            if (shouldLandAtTarget) {
+                if (!mob.level().isEmptyBlock(mob.blockPosition().below())) {
                     mob.onReachAirTarget(BlockPos.containing(flyingWanted));
+                    mob.setFlying(false);
+                    mob.setXRot(0);
                     operation = Operation.WAIT;
                 }
+            } else {
+                mob.onReachAirTarget(BlockPos.containing(flyingWanted));
+                operation = Operation.WAIT;
             }
-            if (mob.verticalCollisionBelow && offset.y < 0) {
-                if (!mob.isUsingStuckNavigation()) {
-                    if (offset.horizontalDistance() < 6 && offset.y > -3) {
-                        //Just walk if close enough
-                        mob.setFlying(false);
-                        operation = Operation.WAIT;
-                        mob.moveTo(flyingWanted, true, false);
-                        //TODO: Maybe onReachGroundTarget?
-                    } else {
-                        mob.doStuckNavigation(flyingWanted);
-                    }
+        }
+
+        Vec3 offset2 = flyingWanted.subtract(mob.position());
+        if (mob.verticalCollisionBelow && offset2.y < 0) {
+            if (!mob.isUsingStuckNavigation()) {
+                if (offset2.horizontalDistance() < 6 && offset2.y > -3) {
+                    mob.setFlying(false);
+                    operation = Operation.WAIT;
+                    mob.moveTo(flyingWanted, true, false);
+                } else {
+                    mob.doStuckNavigation(flyingWanted);
                 }
-            } else if (mob.horizontalCollision || mob.verticalCollision) {
-                doStuckDetection(mob.position());
             }
-        } else {
-            mob.setNoGravity(false);
+        } else if (mob.horizontalCollision || mob.verticalCollision) {
+            doStuckDetection(mob.position());
         }
     }
 
     private void doStuckDetection(Vec3 pos) {
         tick++;
-        if (tick - lastStuckCheck > 100) {
+        if (tick - lastStuckCheck > 10) {
             if (pos.distanceToSqr(lastStuckCheckPos) < 2.25) {
                 if (mob.isUsingStuckNavigation()) {
                     mob.getNavigation().recomputePath();

--- a/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/prehistoric/base/PrehistoricFlying.java
+++ b/common/src/main/java/com/github/teamfossilsarcheology/fossil/entity/prehistoric/base/PrehistoricFlying.java
@@ -51,6 +51,8 @@ import org.jetbrains.annotations.Nullable;
 import software.bernie.geckolib.core.animation.AnimatableManager;
 
 public abstract class PrehistoricFlying extends Prehistoric implements FlyingAnimal {
+    public static boolean DEBUG_FLIGHT = false;
+
     private static final EntityDataAccessor<Boolean> FLYING = SynchedEntityData.defineId(PrehistoricFlying.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> TAKING_OFF = SynchedEntityData.defineId(PrehistoricFlying.class, EntityDataSerializers.BOOLEAN);
     private static final EntityDataAccessor<Boolean> FLYING_UP = SynchedEntityData.defineId(PrehistoricFlying.class, EntityDataSerializers.BOOLEAN);
@@ -102,7 +104,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         goalSelector.addGoal(Util.LOOK, new LookAtPlayerGoal(this, Player.class, 8));
         goalSelector.addGoal(Util.LOOK + 1, new RandomLookAroundGoal(this));
         targetSelector.addGoal(5, new HuntingTargetGoal(this));
-
         targetSelector.addGoal(4, new NearestAttackableTargetGoal<>(this, LaserPointEntity.class, true));
     }
 
@@ -153,9 +154,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         updatePose();
     }
 
-    /**
-     * If the mob should fly up and look up while being ridden
-     */
     public boolean isFlyingUp() {
         return entityData.get(FLYING_UP);
     }
@@ -164,9 +162,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         entityData.set(FLYING_UP, flyingUp);
     }
 
-    /**
-     * If the mob should fly down and look down while being ridden
-     */
     public boolean isFlyingDown() {
         return flyingDown;
     }
@@ -183,7 +178,7 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
     public void switchNavigator(boolean fly) {
         usingStuckNavigation = fly;
         if (fly) {
-            navigation = new FlightPathNavigation(this, level());//TODO: Maybe use custom class that works better with our larger mobs
+            navigation = new FlightPathNavigation(this, level());
         } else {
             navigation = createNavigation(level());
         }
@@ -283,7 +278,7 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
             }
             if (flyingTicks > 80 && onGround()) {
                 groundTicks++;
-                if (groundTicks > 80) {
+                if (groundTicks > 5) {
                     setFlying(false);
                 }
             } else {
@@ -295,6 +290,15 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
             }
             if (isFlyingUp() && (!isFlying() || !isVehicle())) {
                 setFlyingUp(false);
+            }
+
+            if (isFlying() && !isVehicle()) {
+                double ceilDist  = ceilingDistance(getBbHeight() + 4.0);
+                double threshold = getBbHeight() + 2.0;
+                if (ceilDist < threshold) {
+                    double strength = (threshold - ceilDist) / threshold * 0.15;
+                    setDeltaMovement(getDeltaMovement().add(0, -strength, 0));
+                }
             }
         }
     }
@@ -348,7 +352,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
             control.setFlyingTarget(pos.x, pos.y, pos.z, shouldLand);
             control.setOperation(Operation.WAIT);
         } else if (distanceToSqr(pos) > 40 || shouldFly) {
-            //start fly
             if (hasTakeOffAnimation()) {
                 startTakeOff();
                 control.setFlyingTarget(pos.x, pos.y, pos.z, shouldLand);
@@ -359,7 +362,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
                 control.setOperation(Operation.MOVE_TO);
             }
         } else {
-            //walk
             getNavigation().moveTo(pos.x, pos.y, pos.z, 1);
         }
     }
@@ -374,9 +376,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         getAnimationLogic().triggerAnimation(AnimationLogic.IDLE_CTRL, nextTakeOffAnimation(), AnimationCategory.NONE);
     }
 
-    /**
-     * Finish the take-off process and start flying afterward
-     */
     public void finishTakeOff() {
         entityData.set(TAKING_OFF, false);
         takeOffStartTick = -1;
@@ -386,9 +385,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         }
     }
 
-    /**
-     * Cancel the take-off process and don't start flying afterward
-     */
     public void cancelTakeOff() {
         entityData.set(TAKING_OFF, false);
         takeOffStartTick = -1;
@@ -400,7 +396,6 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
     }
 
     public void onReachAirTarget(BlockPos target) {
-
     }
 
     public @Nullable BlockPos getBlockInView() {
@@ -427,14 +422,49 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
         return false;
     }
 
+    private double ceilingDistance(double maxDist) {
+        Vec3 centre = position().add(0, getBbHeight() * 0.5, 0);
+        Vec3 end    = centre.add(0, maxDist, 0);
+        BlockHitResult hit = level().clip(new ClipContext(
+                centre, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
+        return hit.getType() == HitResult.Type.MISS ? maxDist : centre.distanceTo(hit.getLocation());
+    }
+
+    private boolean hasCeilingClearance(Vec3 candidate, double clearance) {
+        Vec3 centre = candidate.add(0, getBbHeight() * 0.5, 0);
+        Vec3 end    = centre.add(0, clearance, 0);
+        BlockHitResult hit = level().clip(new ClipContext(
+                centre, end, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
+        return hit.getType() == HitResult.Type.MISS;
+    }
+
     public @Nullable Vec3 generateAirTarget() {
+        double minClearance = getBbHeight() + 2.0;
+
+        double minGroundClearance = Math.max(8.0, getBbWidth() * 4.0);
+        BlockHitResult floorHit = level().clip(new ClipContext(
+                position(), position().add(0, -(minGroundClearance + 32), 0),
+                ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this));
+        double groundY = floorHit.getType() != HitResult.Type.MISS
+                ? floorHit.getLocation().y
+                : level().getMinBuildHeight();
+        double minY = groundY + minGroundClearance;
+
+        double ceilDist  = ceilingDistance(24);
+        double ceilBias  = 0.0;
+        if (ceilDist < 16) {
+            ceilBias = 1.0 - (ceilDist / 16.0);
+        }
+
         BlockHitResult[] results = new BlockHitResult[10];
         for (int i = 0; i < 10; i++) {
-            float heightMod = (float) (getY() + 1) / (float) (level().getHeight(Heightmap.Types.MOTION_BLOCKING, (int) getX(), (int) getZ()) + 10);
-            double targetX = getX() + (double) ((random.nextFloat() * 2 - 1) * 16);
-            double targetY = getY() + (double) ((random.nextFloat() * 2 - heightMod) * 16);
-            double targetZ = getZ() + (double) ((random.nextFloat() * 2 - 1) * 16);
+            double hRange = 16 + random.nextFloat() * 14;
+            double targetX = getX() + (double) ((random.nextFloat() * 2 - 1) * hRange);
+            double targetY = getY() + (double) ((random.nextFloat() * 2 - 1 - ceilBias) * 16);
+            targetY = Math.max(targetY, minY);
+            double targetZ = getZ() + (double) ((random.nextFloat() * 2 - 1) * hRange);
             Vec3 pos = new Vec3(targetX, targetY, targetZ);
+
             BlockHitResult result = level().clip(new ClipContext(position(), pos, ClipContext.Block.COLLIDER, isInWater() ? ClipContext.Fluid.NONE : ClipContext.Fluid.ANY, this));
             results[i] = result;
             BlockPos.MutableBlockPos mutable = result.getBlockPos().mutable();
@@ -442,21 +472,31 @@ public abstract class PrehistoricFlying extends Prehistoric implements FlyingAni
                 mutable.move(0, 1, 0);
             }
             results[i] = new BlockHitResult(result.getLocation(), result.getDirection(), mutable.immutable(), result.isInside());
-            if (result.getType() == HitResult.Type.MISS) {
+
+            if (result.getType() == HitResult.Type.MISS && hasCeilingClearance(pos, minClearance)) {
+                return pos;
+            }
+            if (!isFlying() && hasCeilingClearance(pos, minClearance)) {
                 return pos;
             }
         }
-        //If there is no direct path to all the targets we instead look for the one farthest away
+
         BlockHitResult furthest = null;
         double distance = 5;
         for (int i = 1; i < results.length; i++) {
             double g = position().distanceTo(results[i].getLocation());
             if (g > distance) {
-                furthest = results[i];
-                distance = g;
+                Vec3 candidate = Vec3.atCenterOf(results[i].getBlockPos().relative(results[i].getDirection()));
+                if (hasCeilingClearance(candidate, minClearance)) {
+                    furthest = results[i];
+                    distance = g;
+                }
             }
         }
-        return furthest != null ? Vec3.atCenterOf(furthest.getBlockPos().relative(furthest.getDirection())) : null;
+        if (furthest != null) {
+            return Vec3.atCenterOf(furthest.getBlockPos().relative(furthest.getDirection()));
+        }
+        return null;
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-mod_version=9.3.2.1
+mod_version=9.3.2.0
 maven_group=com.github.teamfossilsarcheology.fossils-archeology-revival
 archives_name=fossils-archeology-revival
 java_version=17


### PR DESCRIPTION
Rewrites CustomFlightMoveControl, PrehistoricFlying, and FlyingWanderGoal to fix ceiling hugging, ground-skimming targets, mobs landing too frequently, and pitch tilt persisting after landing. Mobs now cruise at a proper minimum altitude, hover between waypoints instead of falling, recover from wall collisions in ~0.5s, and fly for roughly a minute before deciding to land.